### PR TITLE
Update StaffRepository.php

### DIFF
--- a/src/AppBundle/Repository/StaffRepository.php
+++ b/src/AppBundle/Repository/StaffRepository.php
@@ -26,7 +26,7 @@ class StaffRepository extends EntityRepository
 	public function findDeptOrderedByNameOnce() {
 		return $this->getEntityManager()
             ->createQuery(
-                'SELECT a 
+                'SELECT a.department 
                 FROM AppBundle:Staff a
                 GROUP BY a.department'
             )


### PR DESCRIPTION
Got this error when trying to access /departments:

_SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'symfony.s0.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by_

Turns out only_full_group_by is a new (and default) mode in mysql 5.7 where it will not perform GROUP BY if it doesn't know how to resolve columns that are returned, but not aggregated or grouped.

For example, your query would have returned the staff's "name" property. Buy mysql would not know which one to return.